### PR TITLE
Upgrade to Elasticsearch 7.2.0

### DIFF
--- a/elasticsearch/src/test/groovy/io/micronaut/configuration/elasticsearch/health/ElasticsearchHealthIndicatorSpec.groovy
+++ b/elasticsearch/src/test/groovy/io/micronaut/configuration/elasticsearch/health/ElasticsearchHealthIndicatorSpec.groovy
@@ -38,7 +38,7 @@ class ElasticsearchHealthIndicatorSpec extends Specification {
 
     void "test elasticsearch health indicator"() {
         given:
-        ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.1.0")
+        ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.2.0")
         container.start()
 
         final CredentialsProvider credentialsProvider = new BasicCredentialsProvider()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 projectVersion=2.0.0
 micronautVersion=1.1.0
 developers=Puneet Behl
-elasticsearchVersion=7.1.0
+elasticsearchVersion=7.2.0
 githubBranch=master
 githubSlug=micronaut-projects/micronaut-elasticsearch
 groovyVersion=2.5.3

--- a/test-suite/src/test/groovy/io/micronaut/docs/configuration/elasticsearch/ElasticsearchSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/docs/configuration/elasticsearch/ElasticsearchSpec.groovy
@@ -30,9 +30,9 @@ import org.apache.http.client.CredentialsProvider
 import org.apache.http.impl.client.BasicCredentialsProvider
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
 import org.elasticsearch.Version
-import org.elasticsearch.action.main.MainResponse
 import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.RestHighLevelClient
+import org.elasticsearch.client.core.MainResponse
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 import spock.lang.Shared
 import spock.lang.Specification
@@ -48,7 +48,7 @@ import javax.inject.Singleton
 class ElasticsearchSpec extends Specification {
 
     // tag::es-testcontainer[]
-    @Shared ElasticsearchContainer elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.1.0")
+    @Shared ElasticsearchContainer elasticsearch = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.2.0")
 
     // end::es-testcontainer[]
 
@@ -72,8 +72,8 @@ class ElasticsearchSpec extends Specification {
         //end::query[]
 
         then:
-        "docker-cluster" == response.getClusterName().value()
-        Version.fromString("7.1.0") == response.getVersion()
+        "docker-cluster" == response.getClusterName()
+        Version.fromString("7.2.0").toString() == response.getVersion().getNumber()
 
         cleanup:
         applicationContext.close()


### PR DESCRIPTION
The MainResponse and GetIndexRequest classes became dedicated client classes, with slightly different methods, which required some slight changes in the test.