### PR TITLE
Refactor Eleasticsearch healthcheck to be reactive

### DIFF
--- a/elasticsearch/src/main/java/io/micronaut/configuration/elasticsearch/health/ElasticsearchHealthIndicator.java
+++ b/elasticsearch/src/main/java/io/micronaut/configuration/elasticsearch/health/ElasticsearchHealthIndicator.java
@@ -21,12 +21,11 @@ import io.micronaut.health.HealthStatus;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthIndicator;
 import io.micronaut.management.health.indicator.HealthResult;
-import io.reactivex.Flowable;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -36,12 +35,18 @@ import org.reactivestreams.Publisher;
 import javax.inject.Singleton;
 import java.io.IOException;
 
+import static io.micronaut.health.HealthStatus.DOWN;
+import static io.micronaut.health.HealthStatus.UP;
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.cluster.health.ClusterHealthStatus.GREEN;
+import static org.elasticsearch.cluster.health.ClusterHealthStatus.YELLOW;
 
 /**
- * A  {@link HealthIndicator} for Elasticsearch High Level REST client.
+ * A {@link HealthIndicator} for Elasticsearch that uses an automatically-configured high-level REST client, injected as a dependency, to communicate
+ * with Elasticsearch.
  *
  * @author Puneet Behl
+ * @author Robyn Dalgleish
  * @since 1.0.0
  */
 @Requires(beans = HealthEndpoint.class)
@@ -49,43 +54,66 @@ import static java.util.Collections.emptyMap;
 @Singleton
 public class ElasticsearchHealthIndicator implements HealthIndicator {
 
-    public static final String NAME = "elasticsearch-rest-high-level";
-    private final RestHighLevelClient restHighLevelClient;
+    private static final String NAME = "elasticsearch";
+
+    private final RestHighLevelClient esClient;
 
     /**
      * Constructor.
      *
-     * @param restHighLevelClient The Elasticsearch high level REST client.
+     * @param esClient The Elasticsearch high level REST client.
      */
-    public ElasticsearchHealthIndicator(RestHighLevelClient restHighLevelClient) {
-        this.restHighLevelClient = restHighLevelClient;
+    public ElasticsearchHealthIndicator(RestHighLevelClient esClient) {
+        this.esClient = esClient;
     }
 
+    /**
+     * Tries to call the cluster info API on Elasticsearch to obtain information about the cluster. If the call succeeds, the Elasticsearch cluster
+     * health status (GREEN / YELLOW / RED) will be included in the health indicator details.
+     *
+     * @return A positive health result UP if the cluster can be communicated with and is in either GREEN or YELLOW status. A negative health result
+     * DOWN if the cluster cannot be communicated with or is in RED status.
+     */
     @Override
     public Publisher<HealthResult> getResult() {
-        HealthResult result = HealthResult.builder(NAME)
-                .status(HealthStatus.UNKNOWN)
-                .build();
-        try {
-            ClusterHealthRequest request = new ClusterHealthRequest();
-            ClusterHealthResponse response = restHighLevelClient.cluster().health(request, RequestOptions.DEFAULT);
-            HealthResult.Builder builder = HealthResult.builder(NAME);
-            ClusterHealthStatus clusterHealthStatus = response.getStatus();
-            if (clusterHealthStatus == ClusterHealthStatus.GREEN) {
-                XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
-                response.toXContent(xContentBuilder, new ToXContent.MapParams(emptyMap()));
-                String details = Strings.toString(xContentBuilder);
-                builder.status(HealthStatus.UP)
-                        .details(details);
-                result = builder.build();
+
+        return (subscriber -> esClient.cluster().healthAsync(new ClusterHealthRequest(), RequestOptions.DEFAULT, new ActionListener<ClusterHealthResponse>() {
+
+            private final HealthResult.Builder resultBuilder = HealthResult.builder(NAME);
+
+            @Override
+            public void onResponse(ClusterHealthResponse response) {
+
+                HealthResult result;
+
+                try {
+                    result = resultBuilder
+                        .status(healthResultStatus(response))
+                        .details(healthResultDetails(response))
+                        .build();
+                } catch (IOException e) {
+                    result = resultBuilder.status(DOWN).exception(e).build();
+                }
+
+                subscriber.onNext(result);
+                subscriber.onComplete();
             }
-        } catch (IOException e) {
-            result = buildErrorResult(e);
-        }
-        return Flowable.just(result);
+
+            @Override
+            public void onFailure(Exception e) {
+                subscriber.onNext(resultBuilder.status(DOWN).exception(e).build());
+                subscriber.onComplete();
+            }
+        }));
     }
 
-    private HealthResult buildErrorResult(Throwable throwable) {
-        return HealthResult.builder(NAME, HealthStatus.DOWN).exception(throwable).build();
+    private String healthResultDetails(ClusterHealthResponse response) throws IOException {
+        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder();
+        response.toXContent(xContentBuilder, new ToXContent.MapParams(emptyMap()));
+        return Strings.toString(xContentBuilder);
+    }
+
+    private HealthStatus healthResultStatus(ClusterHealthResponse response) {
+        return response.getStatus() == GREEN || response.getStatus() == YELLOW ? UP : DOWN;
     }
 }


### PR DESCRIPTION
I have made 2 changes:

- The health result has been changed from DOWN to UP for a health status of YELLOW, because when the health status is YELLOW there is risk of losing data on the Elasticsearch cluster, but the connection with Elasticsearch is still functional and the service can still be considered healthy.
- Also, the implementation is now reactive. Previously, the health indicator was making a blocking call to Elasticsearch. With this change, the asynchronous API on the `RestHighLevelClient` is adapted to the reactive API of `HealthIndicator`.