### PR TITLE
Documentation points to invalid health key

### DIFF
--- a/src/main/docs/guide/healthChecks.adoc
+++ b/src/main/docs/guide/healthChecks.adoc
@@ -2,6 +2,18 @@ When the `elasticsearch` module is activated a api:configuration.elasticsearch.h
 activated resulting in the `/health` endpoint and https://docs.micronaut.io/latest/api/io/micronaut/health/CurrentHealthStatus.html[CurrentHealthStatus]
 interface resolving the health of the Elasticsearch cluster.
 
-The only configuration option supported is to enable or disable the indicator by the `endpoints.health.elasticsearch.enabled` key.
+The only configuration option supported is to enable or disable the indicator.
+
+[source,yaml]
+.application.yml
+----
+endpoints:
+  health:
+    elasticsearch:
+      rest:
+        high:
+          level:
+            enabled: false
+----
 
 See the section on the https://docs.micronaut.io/latest/guide/index.html#healthEndpoint[Health Endpoint] for more information.


### PR DESCRIPTION
The documentation on the elastic search documentation - for the health indicator - was wrong -pointing to an invalid key which obviously was not working when applied.

The change adds the correct key - as found in the source code.