### PR TITLE
Fix vulnerability audit findings on 6.1.x

### DIFF
--- a/elasticsearch/build.gradle.kts
+++ b/elasticsearch/build.gradle.kts
@@ -23,6 +23,24 @@ dependencies {
     testImplementation(mn.reactor)
     testImplementation(platform(mnTest.boms.testcontainers))
     testImplementation(libs.testcontainers.elasticsearch)
+
+    constraints {
+        api(libs.apache.httpclient5) {
+            because("GHSA-hjcp-jmpx-g3qm: elasticsearch-rest5-client brings httpclient5 5.6.1")
+        }
+        api(libs.apache.httpcore5) {
+            because("GHSA-hf6x-8p5f-cgmf: elasticsearch-rest5-client brings httpcore5 5.4")
+        }
+        api(libs.apache.httpcore5.h2) {
+            because("GHSA-v3jc-474w-2wm6: elasticsearch-rest5-client brings httpcore5-h2 5.4")
+        }
+        api(libs.jackson2.core) {
+            because("Keep jackson-core aligned with jackson-databind")
+        }
+        api(libs.jackson2.databind) {
+            because("GHSA-5gvw-p9qm-jgwh: elasticsearch-java brings jackson-databind 2.22.0")
+        }
+    }
 }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "5.1.6"
+micronaut = "5.1.14"
 micronaut-platform = "5.0.5"
 micronaut-security = "5.3.1"
 micronaut-logging = "2.0.0"
@@ -11,6 +11,10 @@ managed-elasticsearch = "9.4.3"
 graal-svm = "25.0.3"
 apache-http-client = "4.5.14"
 apache-http-async-client = "4.1.5"
+# Transitive dependencies of elasticsearch-java upgraded to fix known vulnerabilities
+apache-httpclient5 = "5.6.4"
+apache-httpcore5 = "5.4.3"
+jackson2 = "2.22.2"
 
 [libraries]
 # Core
@@ -22,6 +26,11 @@ managed-elasticsearch-java = { module = "co.elastic.clients:elasticsearch-java",
 managed-elasticsearch-rest-client = { module = "org.elasticsearch.client:elasticsearch-rest-client", version.ref = "managed-elasticsearch" }
 apache-http-client = { module = "org.apache.httpcomponents:httpclient", version.ref = "apache-http-client" }
 apache-http-async-client = { module = "org.apache.httpcomponents:httpasyncclient", version.ref = "apache-http-async-client" }
+apache-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "apache-httpclient5" }
+apache-httpcore5 = { module = "org.apache.httpcomponents.core5:httpcore5", version.ref = "apache-httpcore5" }
+apache-httpcore5-h2 = { module = "org.apache.httpcomponents.core5:httpcore5-h2", version.ref = "apache-httpcore5" }
+jackson2-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson2" }
+jackson2-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson2" }
 graal-svm = { module = "org.graalvm.nativeimage:svm", version.ref = "graal-svm" }
 testcontainers-elasticsearch = { module = "org.testcontainers:testcontainers-elasticsearch" }
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,0 @@
-[[IgnoredVulns]]
-id = "GHSA-5jmj-h7xm-6q6v"
-reason = "com.fasterxml.jackson.core:jackson-databind:2.21.5 (GHSA-5jmj-h7xm-6q6v; fixed: 3.1.4)"


### PR DESCRIPTION
Fixes the failing `audit (25)` check seen on #741, part of the Micronaut core 5.2 rollout tracked in micronaut-projects/micronaut-core#13110.

The audit fails on every open pull request against `6.1.x` (for example #740 and #744), not only on the core bump, so the findings already exist on the branch. There is no new-minor branch yet, so this targets `6.1.x`.

| Finding | Pulled by | Fix |
| --- | --- | --- |
| `httpclient5:5.6.1` (GHSA-hjcp-jmpx-g3qm) | `elasticsearch-java` → `elasticsearch-rest5-client` | constraint to 5.6.4 |
| `httpcore5:5.4` (GHSA-hf6x-8p5f-cgmf) | `httpclient5` | constraint to 5.4.3 |
| `httpcore5-h2:5.4` (GHSA-v3jc-474w-2wm6) | `httpclient5` | constraint to 5.4.3 |
| `com.fasterxml.jackson.core:jackson-databind:2.22.0` (GHSA-5gvw-p9qm-jgwh) | `elasticsearch-java` | constraint to 2.22.2, with `jackson-core` aligned |
| `tools.jackson.core:jackson-databind:3.1.4` (GHSA-5gvw-p9qm-jgwh) | Micronaut core 5.1.6 | core 5.1.6 → 5.1.14, which ships Jackson 3.1.6 |

The last row isn't in the CI output quoted on #741. OSV extended the advisory to Jackson 3 on 2026-09-10, and it now shows up on `6.1.x` without any bump. Core stays on the 5.1 line because `6.1.x` is a released minor. #741's core 5.2.0 (Jackson 3.2.2) would also fix it, but it belongs in a new minor.

The constraints are declared on `api`, matching `elasticsearch-java`, so they are published with the module. `elasticsearch-java` 9.5.3 (#744) still requires Jackson 2.22.0, so the Elasticsearch update alone would not fix any of this.

The only exception in `osv-scanner.toml` (GHSA-5jmj-h7xm-6q6v) no longer matches anything after the upgrade, so the file is removed.

Verified locally:
- `.github/scripts/vulnerability-audit.sh`: "No known vulnerabilities found." Before the change it reported the five findings above on `6.1.x`.
- `./gradlew :micronaut-elasticsearch:check :test-suite-java:check :test-suite-groovy:check`: BUILD SUCCESSFUL (checkstyle, japiCmp and 15 tests: 11 in the module, 1 in test-suite-java, 3 in test-suite-groovy, 0 failures, 0 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
