### PR TITLE
Start 6.2.x at 6.2.0-SNAPSHOT with core 5.2.0

### DIFF
--- a/elasticsearch/build.gradle.kts
+++ b/elasticsearch/build.gradle.kts
@@ -23,6 +23,24 @@ dependencies {
     testImplementation(mn.reactor)
     testImplementation(platform(mnTest.boms.testcontainers))
     testImplementation(libs.testcontainers.elasticsearch)
+
+    constraints {
+        api(libs.apache.httpclient5) {
+            because("GHSA-hjcp-jmpx-g3qm: elasticsearch-rest5-client brings httpclient5 5.6.1")
+        }
+        api(libs.apache.httpcore5) {
+            because("GHSA-hf6x-8p5f-cgmf: elasticsearch-rest5-client brings httpcore5 5.4")
+        }
+        api(libs.apache.httpcore5.h2) {
+            because("GHSA-v3jc-474w-2wm6: elasticsearch-rest5-client brings httpcore5-h2 5.4")
+        }
+        api(libs.jackson2.core) {
+            because("Keep jackson-core aligned with jackson-databind")
+        }
+        api(libs.jackson2.databind) {
+            because("GHSA-5gvw-p9qm-jgwh: elasticsearch-java brings jackson-databind 2.22.0")
+        }
+    }
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=6.1.1-SNAPSHOT
+projectVersion=6.2.0-SNAPSHOT
 projectGroup=io.micronaut.elasticsearch
 title=Micronaut Elasticsearch
 projectDesc=Integration between Micronaut and Elasticsearch

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,10 @@ managed-elasticsearch = "9.4.3"
 graal-svm = "25.0.3"
 apache-http-client = "4.5.14"
 apache-http-async-client = "4.1.5"
+# Transitive dependencies of elasticsearch-java upgraded to fix known vulnerabilities
+apache-httpclient5 = "5.6.4"
+apache-httpcore5 = "5.4.3"
+jackson2 = "2.22.2"
 
 [libraries]
 # Core
@@ -22,6 +26,11 @@ managed-elasticsearch-java = { module = "co.elastic.clients:elasticsearch-java",
 managed-elasticsearch-rest-client = { module = "org.elasticsearch.client:elasticsearch-rest-client", version.ref = "managed-elasticsearch" }
 apache-http-client = { module = "org.apache.httpcomponents:httpclient", version.ref = "apache-http-client" }
 apache-http-async-client = { module = "org.apache.httpcomponents:httpasyncclient", version.ref = "apache-http-async-client" }
+apache-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "apache-httpclient5" }
+apache-httpcore5 = { module = "org.apache.httpcomponents.core5:httpcore5", version.ref = "apache-httpcore5" }
+apache-httpcore5-h2 = { module = "org.apache.httpcomponents.core5:httpcore5-h2", version.ref = "apache-httpcore5" }
+jackson2-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson2" }
+jackson2-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson2" }
 graal-svm = { module = "org.graalvm.nativeimage:svm", version.ref = "graal-svm" }
 testcontainers-elasticsearch = { module = "org.testcontainers:testcontainers-elasticsearch" }
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-micronaut = "5.1.6"
-micronaut-platform = "5.0.5"
-micronaut-security = "5.3.1"
+micronaut = "5.2.0"
+micronaut-platform = "5.1.4"
+micronaut-security = "5.3.2"
 micronaut-logging = "2.0.0"
 micronaut-test = "5.0.0"
 micronaut-test-resources="3.0.0-M1"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,3 +1,0 @@
-[[IgnoredVulns]]
-id = "GHSA-5jmj-h7xm-6q6v"
-reason = "com.fasterxml.jackson.core:jackson-databind:2.21.5 (GHSA-5jmj-h7xm-6q6v; fixed: 3.1.4)"


### PR DESCRIPTION
Starts the new minor branch `6.2.x` (created from `6.1.x`) at `6.2.0-SNAPSHOT` and moves it to Micronaut core 5.2.0.

Core 5.2 may only land in a new, unreleased minor of each library, so it does not go to `6.1.x`, whose minor is already released. Tracked in micronaut-projects/micronaut-core#13110.

The `gradle/libs.versions.toml` changes of the Renovate PR #741 on `6.1.x` are reused here.
Switching the default and Renovate base branch to `6.2.x` is left to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)