### PR TITLE
Update to Micronaut core 5.2.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "5.2.0"
+micronaut = "5.2.1"
 micronaut-platform = "5.1.4"
 micronaut-security = "5.3.2"
 micronaut-logging = "2.0.0"


### PR DESCRIPTION
Moves `6.2.x` from core 5.2.0 to the released core 5.2.1, which carries the 5.2 regression fixes tracked in micronaut-projects/micronaut-core#13110.

Renovate's earlier PR micronaut-projects/micronaut-elasticsearch#741 targeted `6.1.x`, whose minor is already released, so it was closed; the core 5.2 work landed on this branch in micronaut-projects/micronaut-elasticsearch#746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)